### PR TITLE
Add fake lighting system for custom ships

### DIFF
--- a/blockships/build.gradle.kts
+++ b/blockships/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "anon.def9a2a4"
-version = "0.0.11"
+version = "0.0.13"
 
 java {
     toolchain {

--- a/blockships/src/main/java/anon/def9a2a4/blockships/ShipModel.java
+++ b/blockships/src/main/java/anon/def9a2a4/blockships/ShipModel.java
@@ -34,6 +34,7 @@ public final class ShipModel {
 
     public final List<SeatInfo> seats;     // Multiple seat positions, in order they appear in model file
     public final List<CannonInfo> cannons; // Detected cannons (dispenser + obsidian behind)
+    public final List<LightSource> lightSources;  // Light-emitting blocks for fake lighting
     public final float waterFloatOffset;   // Y-position offset from water surface where ship floats (for prefab ships)
 
     // Buoyancy system (for custom block ships)
@@ -52,7 +53,7 @@ public final class ShipModel {
 
     public ShipModel(List<ModelPart> parts, List<ItemPart> items, Vector3f initialRotation, Vector3f positionOffset,
                      Vector3f collisionOffset, Matrix3f rotationTransform, List<SeatInfo> seats, List<CannonInfo> cannons,
-                     float waterFloatOffset, double maxHealth, double healthRegenPerSecond,
+                     List<LightSource> lightSources, float waterFloatOffset, double maxHealth, double healthRegenPerSecond,
                      int totalWeight, int blockCount, Vector3f centerOfVolume, float minY, float maxY, float assemblyYaw) {
         this.parts = parts;
         this.items = items;
@@ -62,6 +63,7 @@ public final class ShipModel {
         this.rotationTransform = rotationTransform;
         this.seats = seats;
         this.cannons = cannons;
+        this.lightSources = lightSources;
         this.waterFloatOffset = waterFloatOffset;
         this.maxHealth = maxHealth;
         this.healthRegenPerSecond = healthRegenPerSecond;
@@ -378,8 +380,11 @@ public final class ShipModel {
         // Prefab ships don't use weight-based buoyancy - they use waterFloatOffset from YAML
         // Set weight/blockCount to 0, centerOfVolume to origin, minY/maxY to 0, and assemblyYaw to 0 (prefab ships don't rotate on assembly)
         // Prefab ships have no cannons (empty list)
+        // Prefab ships don't use weight-based buoyancy - they use waterFloatOffset from YAML
+        // Set weight/blockCount to 0, centerOfVolume to origin, minY/maxY to 0, and assemblyYaw to 0 (prefab ships don't rotate on assembly)
+        // Prefab ships have no cannons or light sources (empty lists)
         return new ShipModel(out, items, initialRotation, positionOffset, collisionOffset, rotationTransform,
-                           seats, new ArrayList<>(), waterFloatOffset, maxHealth, healthRegenPerSecond,
+                           seats, new ArrayList<>(), new ArrayList<>(), waterFloatOffset, maxHealth, healthRegenPerSecond,
                            0, 0, new Vector3f(0, 0, 0), 0f, 0f, 0f);
     }
 
@@ -571,6 +576,37 @@ public final class ShipModel {
         }
     }
 
+    /**
+     * Represents a light-emitting block on the ship for fake lighting with LIGHT blocks.
+     * The LIGHT block is placed at the position of the target shulker (collision box).
+     */
+    public static final class LightSource {
+        public final int blockIndex;              // Index of the light-emitting block in model.parts
+        public final int targetShulkerBlockIndex; // Index of the block whose shulker to use for positioning
+        public final int lightLevel;              // 0-15 light level from source block
+
+        public LightSource(int blockIndex, int targetShulkerBlockIndex, int lightLevel) {
+            this.blockIndex = blockIndex;
+            this.targetShulkerBlockIndex = targetShulkerBlockIndex;
+            this.lightLevel = java.lang.Math.max(0, java.lang.Math.min(15, lightLevel));  // Clamp to valid range
+        }
+
+        public Map<String, Object> toMap() {
+            Map<String, Object> map = new HashMap<>();
+            map.put("block_index", blockIndex);
+            map.put("target_shulker_block_index", targetShulkerBlockIndex);
+            map.put("light_level", lightLevel);
+            return map;
+        }
+
+        public static LightSource fromMap(Map<String, Object> map) {
+            int blockIndex = ((Number) map.get("block_index")).intValue();
+            int targetShulkerBlockIndex = ((Number) map.get("target_shulker_block_index")).intValue();
+            int lightLevel = ((Number) map.get("light_level")).intValue();
+            return new LightSource(blockIndex, targetShulkerBlockIndex, lightLevel);
+        }
+    }
+
     // ===== Serialization for custom ship persistence =====
 
     /**
@@ -624,6 +660,13 @@ public final class ShipModel {
             cannonsList.add(cannon.toMap());
         }
         map.put("cannons", cannonsList);
+
+        // Serialize light sources
+        List<Map<String, Object>> lightsList = new ArrayList<>();
+        for (LightSource light : lightSources) {
+            lightsList.add(light.toMap());
+        }
+        map.put("light_sources", lightsList);
 
         return map;
     }
@@ -729,6 +772,16 @@ public final class ShipModel {
             }
         }
 
+        // Deserialize light sources
+        List<LightSource> lightSources = new ArrayList<>();
+        if (map.containsKey("light_sources")) {
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> lightsList = (List<Map<String, Object>>) map.get("light_sources");
+            for (Map<String, Object> lightMap : lightsList) {
+                lightSources.add(LightSource.fromMap(lightMap));
+            }
+        }
+
         // Custom ships use assemblyYaw for display rotation (must match BlockStructureScanner)
         Vector3f initialRotation = new Vector3f(assemblyYaw, 0, 0);
         Vector3f positionOffset = new Vector3f(0, 0, 0);
@@ -739,7 +792,7 @@ public final class ShipModel {
         double healthRegenPerSecond = 2.0;
 
         return new ShipModel(parts, new ArrayList<>(), initialRotation, positionOffset,
-            collisionOffset, rotationTransform, seats, cannons, waterFloatOffset,
+            collisionOffset, rotationTransform, seats, cannons, lightSources, waterFloatOffset,
             maxHealth, healthRegenPerSecond, totalWeight, blockCount,
             centerOfVolume, minY, maxY, assemblyYaw);
     }

--- a/blockships/src/main/java/anon/def9a2a4/blockships/blockconfig/BlockConfigManager.java
+++ b/blockships/src/main/java/anon/def9a2a4/blockships/blockconfig/BlockConfigManager.java
@@ -137,6 +137,12 @@ public class BlockConfigManager {
         // Parse storage config if present
         ShipModel.StorageConfig storage = parseStorage(config.getConfigurationSection("storage"));
 
+        // Parse light_level - null means use Minecraft default
+        Integer lightLevel = null;
+        if (config.contains("light_level")) {
+            lightLevel = config.getInt("light_level");
+        }
+
         // Check for conditional rules
         if (config.contains("collider.type") && config.getString("collider.type").equals("conditional")) {
             // Has conditional rules - rules is a YAML list, not a section
@@ -144,13 +150,13 @@ public class BlockConfigManager {
 
             // Parse conditional properties
             List<BlockProperties.ConditionalRule> conditionalRules = parseConditionalRules(rulesList);
-            BlockProperties baseProps = new BlockProperties(allowed, weight, CollisionConfig.DEFAULT, leadable, seat, displayRotation, interaction, storage, conditionalRules);
+            BlockProperties baseProps = new BlockProperties(allowed, weight, CollisionConfig.DEFAULT, leadable, seat, displayRotation, interaction, storage, lightLevel, conditionalRules);
 
             applyToMaterials(key, baseProps);
         } else {
             // Simple non-conditional properties
             CollisionConfig collider = parseCollider(config.get("collider"));
-            BlockProperties props = new BlockProperties(allowed, weight, collider, leadable, seat, displayRotation, interaction, storage, null);
+            BlockProperties props = new BlockProperties(allowed, weight, collider, leadable, seat, displayRotation, interaction, storage, lightLevel, null);
 
             applyToMaterials(key, props);
         }
@@ -378,5 +384,22 @@ public class BlockConfigManager {
             return new BlockProperties(false, 0, CollisionConfig.NONE, false, false);
         }
         return props;
+    }
+
+    /**
+     * Get the effective light level for a block.
+     * Returns the configured light_level if set, otherwise uses Minecraft's default emission level.
+     *
+     * @param material The block material
+     * @param blockData The block data (for state-specific properties)
+     * @return The light level (0-15), or 0 if the block doesn't emit light
+     */
+    public int getEffectiveLightLevel(Material material, BlockData blockData) {
+        BlockProperties props = getProperties(material, blockData);
+        if (props.hasLightLevel()) {
+            return props.getLightLevel();
+        }
+        // Fall back to Minecraft's default light emission
+        return blockData.getLightEmission();
     }
 }

--- a/blockships/src/main/java/anon/def9a2a4/blockships/blockconfig/BlockProperties.java
+++ b/blockships/src/main/java/anon/def9a2a4/blockships/blockconfig/BlockProperties.java
@@ -18,25 +18,30 @@ public class BlockProperties {
     private final boolean displayRotation;  // true = BlockDisplay ignores facing, apply rotation manually
     private final boolean interaction;  // true = block opens workbench-style GUI when clicked
     private final ShipModel.StorageConfig storage;  // storage config for container blocks
+    private final Integer lightLevel;  // null = use Minecraft default, or override light level 0-15
     private final List<ConditionalRule> conditionalRules;
 
     public BlockProperties(boolean allowed, Integer weight, CollisionConfig collider, boolean leadable, boolean seat) {
-        this(allowed, weight, collider, leadable, seat, false, false, null, null);
+        this(allowed, weight, collider, leadable, seat, false, false, null, null, null);
     }
 
     public BlockProperties(boolean allowed, Integer weight, CollisionConfig collider, boolean leadable, boolean seat, List<ConditionalRule> conditionalRules) {
-        this(allowed, weight, collider, leadable, seat, false, false, null, conditionalRules);
+        this(allowed, weight, collider, leadable, seat, false, false, null, null, conditionalRules);
     }
 
     public BlockProperties(boolean allowed, Integer weight, CollisionConfig collider, boolean leadable, boolean seat, boolean displayRotation, List<ConditionalRule> conditionalRules) {
-        this(allowed, weight, collider, leadable, seat, displayRotation, false, null, conditionalRules);
+        this(allowed, weight, collider, leadable, seat, displayRotation, false, null, null, conditionalRules);
     }
 
     public BlockProperties(boolean allowed, Integer weight, CollisionConfig collider, boolean leadable, boolean seat, boolean displayRotation, boolean interaction, List<ConditionalRule> conditionalRules) {
-        this(allowed, weight, collider, leadable, seat, displayRotation, interaction, null, conditionalRules);
+        this(allowed, weight, collider, leadable, seat, displayRotation, interaction, null, null, conditionalRules);
     }
 
     public BlockProperties(boolean allowed, Integer weight, CollisionConfig collider, boolean leadable, boolean seat, boolean displayRotation, boolean interaction, ShipModel.StorageConfig storage, List<ConditionalRule> conditionalRules) {
+        this(allowed, weight, collider, leadable, seat, displayRotation, interaction, storage, null, conditionalRules);
+    }
+
+    public BlockProperties(boolean allowed, Integer weight, CollisionConfig collider, boolean leadable, boolean seat, boolean displayRotation, boolean interaction, ShipModel.StorageConfig storage, Integer lightLevel, List<ConditionalRule> conditionalRules) {
         this.allowed = allowed;
         this.weight = weight;
         this.collider = collider;
@@ -45,6 +50,7 @@ public class BlockProperties {
         this.displayRotation = displayRotation;
         this.interaction = interaction;
         this.storage = storage;
+        this.lightLevel = lightLevel;
         this.conditionalRules = conditionalRules;
     }
 
@@ -100,6 +106,20 @@ public class BlockProperties {
      */
     public ShipModel.StorageConfig getStorage() {
         return storage;
+    }
+
+    /**
+     * Returns true if this block has an explicit light level configured.
+     */
+    public boolean hasLightLevel() {
+        return lightLevel != null;
+    }
+
+    /**
+     * Returns the configured light level for this block, or null if using Minecraft default.
+     */
+    public Integer getLightLevel() {
+        return lightLevel;
     }
 
     /**

--- a/blockships/src/main/java/anon/def9a2a4/blockships/customships/BlockStructureScanner.java
+++ b/blockships/src/main/java/anon/def9a2a4/blockships/customships/BlockStructureScanner.java
@@ -1091,6 +1091,9 @@ public class BlockStructureScanner {
             lightSources.add(new ShipModel.LightSource(i, targetShulkerBlockIndex, lightLevel));
         }
 
+        // Sort by light level descending so brightest lights are placed first when maxLights is reached
+        lightSources.sort((a, b) -> Integer.compare(b.lightLevel, a.lightLevel));
+
         return lightSources;
     }
 

--- a/blockships/src/main/java/anon/def9a2a4/blockships/customships/BlockStructureScanner.java
+++ b/blockships/src/main/java/anon/def9a2a4/blockships/customships/BlockStructureScanner.java
@@ -545,6 +545,9 @@ public class BlockStructureScanner {
         // Detect cannons (dispenser + obsidian behind)
         List<ShipModel.CannonInfo> cannons = detectCannons(parts);
 
+        // Detect light sources (light-emitting blocks that are not fully enclosed)
+        List<ShipModel.LightSource> lightSources = detectLightSources(parts, shipBlocks, configManager);
+
         return new ShipModel(
             parts,
             Collections.emptyList(),  // No items for MVP
@@ -554,6 +557,7 @@ public class BlockStructureScanner {
             rotationTransform,
             seats,
             cannons,
+            lightSources,
             waterFloatOffset,
             maxHealth,
             healthRegenPerSecond,
@@ -617,7 +621,8 @@ public class BlockStructureScanner {
             Material type = block.getType();
 
             // Check if block location is replaceable (air or similar)
-            if (!type.isAir() && type != Material.WATER && type != Material.LAVA) {
+            // LIGHT blocks are ignored because they may be ship lighting that hasn't been cleaned up yet
+            if (!type.isAir() && type != Material.WATER && type != Material.LAVA && type != Material.LIGHT) {
                 if (FragileBlocks.isFragile(type)) {
                     fragile++;
                 } else {
@@ -682,7 +687,8 @@ public class BlockStructureScanner {
             Material existingType = block.getType();
 
             // Handle conflicts in force mode
-            if (!existingType.isAir() && existingType != Material.WATER && existingType != Material.LAVA) {
+            // LIGHT blocks are always replaceable (ship lighting that hasn't been cleaned up yet)
+            if (!existingType.isAir() && existingType != Material.WATER && existingType != Material.LAVA && existingType != Material.LIGHT) {
                 if (force && FragileBlocks.isFragile(existingType)) {
                     // Destroy fragile block (no drops)
                     block.setType(Material.AIR, false);
@@ -1008,6 +1014,161 @@ public class BlockStructureScanner {
         }
 
         return cannons;
+    }
+
+    /**
+     * Detects light-emitting blocks on the ship that are not fully enclosed.
+     * Interior blocks (surrounded by solid blocks on all 6 sides) are excluded
+     * since they wouldn't emit visible light anyway.
+     *
+     * For blocks with colliders (like glowstone), the LIGHT block is placed at their shulker.
+     * For blocks without colliders (like torches/lanterns), the LIGHT block is placed at the
+     * shulker of the block they're attached to.
+     *
+     * @param parts The list of model parts (blocks) on the ship
+     * @param shipBlocks The set of all ship block locations (unused, kept for API compatibility)
+     * @param configManager The block config manager for getting light levels
+     * @return List of light sources for fake lighting
+     */
+    private static List<ShipModel.LightSource> detectLightSources(
+            List<ShipModel.ModelPart> parts,
+            Set<Location> shipBlocks,
+            BlockConfigManager configManager) {
+
+        List<ShipModel.LightSource> lightSources = new ArrayList<>();
+
+        // Build position -> blockIndex map for parent block lookup
+        Map<String, Integer> positionToIndex = new HashMap<>();
+        Map<String, Boolean> solidPositions = new HashMap<>();
+        for (int i = 0; i < parts.size(); i++) {
+            ShipModel.ModelPart part = parts.get(i);
+            Vector3f pos = new Vector3f();
+            part.local.getTranslation(pos);
+            String key = posKey(pos);
+            positionToIndex.put(key, i);
+            solidPositions.put(key, part.block.getMaterial().isOccluding());
+        }
+
+        // Check each block for light emission
+        for (int i = 0; i < parts.size(); i++) {
+            ShipModel.ModelPart part = parts.get(i);
+            Material material = part.block.getMaterial();
+
+            // Get effective light level (configured or Minecraft default)
+            int lightLevel = configManager.getEffectiveLightLevel(material, part.block);
+            if (lightLevel <= 0) {
+                continue;  // Not a light source
+            }
+
+            // Get block position
+            Vector3f pos = new Vector3f();
+            part.local.getTranslation(pos);
+
+            // Check if this block is interior (surrounded by solid blocks on all 6 sides)
+            if (isInteriorBlock(pos, solidPositions)) {
+                continue;  // Skip interior blocks - no visible light
+            }
+
+            // Find target shulker block index
+            int targetShulkerBlockIndex;
+            if (part.collision.enable) {
+                // Block has its own collider - use it
+                targetShulkerBlockIndex = i;
+            } else {
+                // Block has no collider - find parent block (for torches/lanterns)
+                Integer parentIndex = findParentBlockIndex(part.block, pos, positionToIndex, parts);
+                if (parentIndex == null) {
+                    continue;  // Can't find parent, skip this light
+                }
+                // Verify parent has a collider
+                if (!parts.get(parentIndex).collision.enable) {
+                    continue;  // Parent has no collider, skip
+                }
+                targetShulkerBlockIndex = parentIndex;
+            }
+
+            // This is an exposed light source with a valid shulker target
+            lightSources.add(new ShipModel.LightSource(i, targetShulkerBlockIndex, lightLevel));
+        }
+
+        return lightSources;
+    }
+
+    /**
+     * Finds the block index of the parent block that a torch/lantern is attached to.
+     *
+     * @param blockData The block data of the light-emitting block
+     * @param lightPos The position of the light-emitting block
+     * @param positionToIndex Map from position key to block index
+     * @param parts The list of model parts (for collision checking)
+     * @return The block index of the parent, or null if not found
+     */
+    private static Integer findParentBlockIndex(BlockData blockData, Vector3f lightPos,
+                                                 Map<String, Integer> positionToIndex,
+                                                 List<ShipModel.ModelPart> parts) {
+        Vector3f parentPos = new Vector3f(lightPos);
+
+        // Wall-mounted blocks (wall_torch, etc.) - attached to block behind them
+        if (blockData instanceof org.bukkit.block.data.Directional directional) {
+            BlockFace facing = directional.getFacing();
+            BlockFace parentFace = facing.getOppositeFace();
+            parentPos.add(parentFace.getModX(), parentFace.getModY(), parentFace.getModZ());
+        }
+        // Lanterns - hanging (UP) or floor-standing (DOWN)
+        else if (blockData instanceof org.bukkit.block.data.type.Lantern lantern) {
+            if (lantern.isHanging()) {
+                parentPos.add(0, 1, 0);  // Attached to ceiling
+            } else {
+                parentPos.add(0, -1, 0); // Attached to floor
+            }
+        }
+        // Regular floor torches (non-directional) - attached to block below
+        else {
+            parentPos.add(0, -1, 0);
+        }
+
+        return positionToIndex.get(posKey(parentPos));
+    }
+
+    /**
+     * Creates a position key string for map lookups.
+     */
+    private static String posKey(Vector3f pos) {
+        return Math.round(pos.x) + "," + Math.round(pos.y) + "," + Math.round(pos.z);
+    }
+
+    /**
+     * Checks if a block is fully surrounded by solid blocks on all 6 sides.
+     * Such blocks are considered "interior" and don't need fake lighting.
+     *
+     * @param pos The relative position of the block
+     * @param solidPositions Map of position keys to whether they contain solid blocks
+     * @return true if the block is interior (surrounded), false if exposed
+     */
+    private static boolean isInteriorBlock(Vector3f pos, Map<String, Boolean> solidPositions) {
+        int x = Math.round(pos.x);
+        int y = Math.round(pos.y);
+        int z = Math.round(pos.z);
+
+        // Check all 6 faces
+        int[][] offsets = {
+            {1, 0, 0}, {-1, 0, 0},  // +X, -X
+            {0, 1, 0}, {0, -1, 0},  // +Y, -Y
+            {0, 0, 1}, {0, 0, -1}   // +Z, -Z
+        };
+
+        for (int[] offset : offsets) {
+            String neighborKey = (x + offset[0]) + "," + (y + offset[1]) + "," + (z + offset[2]);
+            Boolean isSolid = solidPositions.get(neighborKey);
+
+            // If neighbor doesn't exist in ship or is not solid, this block is exposed
+            if (isSolid == null || !isSolid) {
+                return false;
+            }
+        }
+
+        // All 6 neighbors are solid ship blocks - this is an interior block
+        return true;
     }
 
     /**

--- a/blockships/src/main/java/anon/def9a2a4/blockships/ship/ShipInstance.java
+++ b/blockships/src/main/java/anon/def9a2a4/blockships/ship/ShipInstance.java
@@ -89,9 +89,10 @@ public class ShipInstance {
     // All config values loaded from config.yml
     public final ShipConfig config;
 
-    // Delegate instances for physics and collision
+    // Delegate instances for physics, collision, and lighting
     public ShipPhysics physics;
     public ShipCollision collision;
+    public ShipLighting lighting;
 
     // Driver and player tracking (public for delegates)
     public boolean hasDriver = false;
@@ -181,6 +182,7 @@ public class ShipInstance {
         // Initialize delegates
         this.physics = new ShipPhysics(this);
         this.collision = new ShipCollision(this);
+        this.lighting = new ShipLighting(this);
 
         // Entity references will be recovered via recoverEntities()
         // vehicle, parent, displays, colliders are null/empty
@@ -306,6 +308,7 @@ public class ShipInstance {
         // Initialize delegates
         this.physics = new ShipPhysics(this);
         this.collision = new ShipCollision(this);
+        this.lighting = new ShipLighting(this);
 
         // Initialize previous state
         this.previousVehicleLocation = vehicle.getLocation().clone();
@@ -1067,6 +1070,7 @@ public class ShipInstance {
         collision.detect();  // Detect collisions and accumulate forces
         physics.update();    // Apply physics (movement, rotation, buoyancy)
         collision.applyResponse();  // Apply collision response
+        lighting.update();           // Update fake light block positions
         updateCollisionPositions();  // Sync collision boxes with vehicle BEFORE movement check
 
         // Get current vehicle state
@@ -1958,6 +1962,8 @@ public class ShipInstance {
             idleCheckTask.cancel();
             idleCheckTask = null;
         }
+        // Clean up LIGHT blocks before suspension
+        if (lighting != null) lighting.cleanup();
         // Clear references (they'll be stale anyway after chunk unloads)
         parent = null;
         displays.clear();
@@ -1971,6 +1977,7 @@ public class ShipInstance {
     public void destroy() {
         if (task != null) task.cancel();
         if (idleCheckTask != null) idleCheckTask.cancel();
+        if (lighting != null) lighting.cleanup();  // Remove all placed LIGHT blocks
         if (parent != null) {
             Entity vehicleEntity = parent.getVehicle();
             if (vehicleEntity != null) {

--- a/blockships/src/main/java/anon/def9a2a4/blockships/ship/ShipLighting.java
+++ b/blockships/src/main/java/anon/def9a2a4/blockships/ship/ShipLighting.java
@@ -1,0 +1,240 @@
+package anon.def9a2a4.blockships.ship;
+
+import anon.def9a2a4.blockships.ShipModel;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.type.Light;
+import org.joml.Matrix4f;
+import org.joml.Vector3f;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Manages fake lighting for ships using invisible LIGHT blocks.
+ * Since ships use display entities (not real blocks), light-emitting blocks
+ * don't actually emit light. This class places real LIGHT blocks at
+ * shulker positions to simulate lighting.
+ */
+public class ShipLighting {
+    private final ShipInstance ship;
+    private final List<Location> placedLights = new ArrayList<>();
+
+    // Tracking for threshold-based updates (reuse vector to reduce GC)
+    private final Vector3f lastUpdatePos = new Vector3f();
+    private boolean hasLastUpdate = false;
+    private float lastUpdateYaw = Float.NaN;
+
+    // Configuration (loaded from plugin config)
+    private final boolean enabled;
+    private final int maxLights;
+    private final float updateThresholdBlocks;
+    private final float updateThresholdRotation;
+
+    // Map from block index to CollisionBox for fast lookup
+    private Map<Integer, CollisionBox> blockIndexToCollider;
+
+    /**
+     * Creates a new ShipLighting manager for the given ship.
+     *
+     * @param ship The ship instance to manage lighting for
+     */
+    public ShipLighting(ShipInstance ship) {
+        this.ship = ship;
+
+        // Load configuration
+        var config = ship.plugin.getConfig();
+        this.enabled = config.getBoolean("custom-ships.lighting.enabled", true);
+        this.maxLights = config.getInt("custom-ships.lighting.max-lights-per-ship", 32);
+        this.updateThresholdBlocks = (float) config.getDouble("custom-ships.lighting.update-threshold-blocks", 1.0);
+        this.updateThresholdRotation = (float) config.getDouble("custom-ships.lighting.update-threshold-rotation", 10.0);
+
+        // Note: blockIndexToCollider is built lazily in placeLights()
+        // because colliders may not be spawned yet when this constructor is called
+    }
+
+    /**
+     * Builds a map from block index to CollisionBox for fast lookup.
+     * Called lazily on first use since colliders may not exist at construction time.
+     */
+    private void buildColliderMap() {
+        blockIndexToCollider = new HashMap<>();
+        for (CollisionBox cb : ship.colliders) {
+            blockIndexToCollider.put(cb.blockIndex, cb);
+        }
+    }
+
+    /**
+     * Updates light block positions if the ship has moved significantly.
+     * Called from ShipInstance.tick() after physics update.
+     */
+    public void update() {
+        if (!enabled || ship.model.lightSources.isEmpty()) {
+            return;
+        }
+
+        if (ship.vehicle == null || !ship.vehicle.isValid()) {
+            return;
+        }
+
+        // Get location once per update cycle (reduces GC pressure)
+        Location vehicleLoc = ship.vehicle.getLocation();
+        float currentYaw = ship.vehicle.getYaw();
+
+        if (!shouldUpdate(vehicleLoc, currentYaw)) {
+            return;
+        }
+
+        // Remove old lights and place new ones
+        int oldCount = placedLights.size();
+        removePlacedLights();
+        placeLights(vehicleLoc.getWorld());
+        ship.plugin.getLogger().info("[ShipLighting] Updated: removed " + oldCount + ", placed " + placedLights.size() + " lights");
+
+        // Track last update position (reuse vector)
+        lastUpdatePos.set((float) vehicleLoc.getX(), (float) vehicleLoc.getY(), (float) vehicleLoc.getZ());
+        lastUpdateYaw = currentYaw;
+        hasLastUpdate = true;
+    }
+
+    /**
+     * Checks if the ship has moved enough to warrant a light update.
+     *
+     * @param vehicleLoc Current vehicle location
+     * @param currentYaw Current vehicle yaw
+     * @return true if lights should be updated
+     */
+    private boolean shouldUpdate(Location vehicleLoc, float currentYaw) {
+        // First update - always do it
+        if (!hasLastUpdate) {
+            return true;
+        }
+
+        float dx = (float) vehicleLoc.getX() - lastUpdatePos.x;
+        float dy = (float) vehicleLoc.getY() - lastUpdatePos.y;
+        float dz = (float) vehicleLoc.getZ() - lastUpdatePos.z;
+        float distSq = dx * dx + dy * dy + dz * dz;
+
+        // Check distance threshold
+        if (distSq >= updateThresholdBlocks * updateThresholdBlocks) {
+            return true;
+        }
+
+        // Check rotation threshold
+        float yawDelta = Math.abs(currentYaw - lastUpdateYaw);
+        // Handle wrap-around (e.g., from 350 to 10 degrees)
+        if (yawDelta > 180) {
+            yawDelta = 360 - yawDelta;
+        }
+
+        return yawDelta >= updateThresholdRotation;
+    }
+
+    /**
+     * Places LIGHT blocks at shulker positions corresponding to ship light sources.
+     *
+     * @param world The world to place lights in
+     */
+    private void placeLights(World world) {
+        if (world == null) {
+            return;
+        }
+
+        // Build collider map lazily (colliders aren't available at construction time)
+        if (blockIndexToCollider == null) {
+            buildColliderMap();
+        }
+
+        int placed = 0;
+        int skippedNoCollider = 0;
+        int skippedNotAir = 0;
+        for (ShipModel.LightSource source : ship.model.lightSources) {
+            if (placed >= maxLights) {
+                break;
+            }
+
+            // Get the collider for this light source's target shulker
+            CollisionBox collider = blockIndexToCollider.get(source.targetShulkerBlockIndex);
+            if (collider == null || collider.entity == null || !collider.entity.isValid()) {
+                skippedNoCollider++;
+                continue;  // No valid shulker for this light
+            }
+
+            // Get shulker center position (getLocation returns feet, add 0.5 for center)
+            Location shulkerLoc = collider.entity.getLocation().add(0, 0.5, 0);
+
+            // Skip if chunk not loaded (avoid forcing chunk loads at boundaries)
+            if (!shulkerLoc.isChunkLoaded()) {
+                continue;
+            }
+
+            Block block = shulkerLoc.getBlock();
+
+            // Only place if target block is air (don't replace existing blocks)
+            if (block.getType().isAir()) {
+                try {
+                    // Create LIGHT block with the appropriate level
+                    BlockData lightData = Material.LIGHT.createBlockData();
+                    if (lightData instanceof Light light) {
+                        light.setLevel(source.lightLevel);
+                    }
+                    // Set block without physics update (false) to avoid cascading updates
+                    block.setBlockData(lightData, false);
+                    placedLights.add(shulkerLoc.clone());
+                    placed++;
+                } catch (Exception e) {
+                    // Silently ignore errors (e.g., chunk not loaded)
+                }
+            } else {
+                skippedNotAir++;
+                ship.plugin.getLogger().info("[ShipLighting] Block at " + block.getX() + "," + block.getY() + "," + block.getZ() + " is " + block.getType());
+            }
+        }
+        if (skippedNoCollider > 0 || skippedNotAir > 0) {
+            ship.plugin.getLogger().info("[ShipLighting] Skipped: " + skippedNoCollider + " no collider, " + skippedNotAir + " not air (total sources: " + ship.model.lightSources.size() + ")");
+        }
+    }
+
+    /**
+     * Removes all LIGHT blocks that were placed by this manager.
+     */
+    public void removePlacedLights() {
+        for (Location loc : placedLights) {
+            try {
+                if (loc.isChunkLoaded()) {
+                    Block block = loc.getBlock();
+                    // Only remove if it's still a LIGHT block (don't remove player-placed blocks)
+                    if (block.getType() == Material.LIGHT) {
+                        block.setType(Material.AIR, false);
+                    }
+                }
+            } catch (Exception e) {
+                // Silently ignore errors
+            }
+        }
+        placedLights.clear();
+    }
+
+    /**
+     * Cleans up all placed lights. Called when the ship is destroyed or suspended.
+     */
+    public void cleanup() {
+        removePlacedLights();
+        hasLastUpdate = false;
+        lastUpdateYaw = Float.NaN;
+    }
+
+    /**
+     * Gets the number of currently placed light blocks.
+     *
+     * @return The number of active light blocks
+     */
+    public int getPlacedLightCount() {
+        return placedLights.size();
+    }
+}

--- a/blockships/src/main/java/anon/def9a2a4/blockships/ship/ShipLighting.java
+++ b/blockships/src/main/java/anon/def9a2a4/blockships/ship/ShipLighting.java
@@ -7,7 +7,6 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.Light;
-import org.joml.Matrix4f;
 import org.joml.Vector3f;
 
 import java.util.ArrayList;
@@ -23,7 +22,7 @@ import java.util.Map;
  */
 public class ShipLighting {
     private final ShipInstance ship;
-    private final List<Location> placedLights = new ArrayList<>();
+    private final List<int[]> placedLights = new ArrayList<>(32);  // {x, y, z} coordinates
 
     // Tracking for threshold-based updates (reuse vector to reduce GC)
     private final Vector3f lastUpdatePos = new Vector3f();
@@ -36,8 +35,8 @@ public class ShipLighting {
     private final float updateThresholdBlocks;
     private final float updateThresholdRotation;
 
-    // Map from block index to CollisionBox for fast lookup
-    private Map<Integer, CollisionBox> blockIndexToCollider;
+    // Array from block index to CollisionBox for fast lookup (indices are dense)
+    private CollisionBox[] blockIndexToCollider;
 
     /**
      * Creates a new ShipLighting manager for the given ship.
@@ -52,20 +51,20 @@ public class ShipLighting {
         this.enabled = config.getBoolean("custom-ships.lighting.enabled", true);
         this.maxLights = config.getInt("custom-ships.lighting.max-lights-per-ship", 32);
         this.updateThresholdBlocks = (float) config.getDouble("custom-ships.lighting.update-threshold-blocks", 1.0);
-        this.updateThresholdRotation = (float) config.getDouble("custom-ships.lighting.update-threshold-rotation", 10.0);
+        this.updateThresholdRotation = (float) config.getDouble("custom-ships.lighting.update-threshold-rotation", 3.0);
 
         // Note: blockIndexToCollider is built lazily in placeLights()
         // because colliders may not be spawned yet when this constructor is called
     }
 
     /**
-     * Builds a map from block index to CollisionBox for fast lookup.
+     * Builds an array from block index to CollisionBox for fast lookup.
      * Called lazily on first use since colliders may not exist at construction time.
      */
-    private void buildColliderMap() {
-        blockIndexToCollider = new HashMap<>();
+    private void buildColliderArray() {
+        blockIndexToCollider = new CollisionBox[ship.model.parts.size()];
         for (CollisionBox cb : ship.colliders) {
-            blockIndexToCollider.put(cb.blockIndex, cb);
+            blockIndexToCollider[cb.blockIndex] = cb;
         }
     }
 
@@ -90,16 +89,26 @@ public class ShipLighting {
             return;
         }
 
-        // Remove old lights and place new ones
-        int oldCount = placedLights.size();
-        removePlacedLights();
-        placeLights(vehicleLoc.getWorld());
-        ship.plugin.getLogger().info("[ShipLighting] Updated: removed " + oldCount + ", placed " + placedLights.size() + " lights");
+        // Place new lights first, then remove old ones (reduces flickering)
+        List<int[]> oldLights = new ArrayList<>(placedLights);
+        placedLights.clear();
+        World world = vehicleLoc.getWorld();
+        placeLights(world);
+        removeOldLights(oldLights, world);
 
         // Track last update position (reuse vector)
         lastUpdatePos.set((float) vehicleLoc.getX(), (float) vehicleLoc.getY(), (float) vehicleLoc.getZ());
         lastUpdateYaw = currentYaw;
         hasLastUpdate = true;
+    }
+
+    /**
+     * Forces an immediate light update regardless of movement thresholds.
+     * Useful after teleportation or other instant position changes.
+     */
+    public void forceUpdate() {
+        hasLastUpdate = false;
+        update();
     }
 
     /**
@@ -145,58 +154,59 @@ public class ShipLighting {
             return;
         }
 
-        // Build collider map lazily (colliders aren't available at construction time)
+        // Build collider array lazily (colliders aren't available at construction time)
         if (blockIndexToCollider == null) {
-            buildColliderMap();
+            buildColliderArray();
         }
 
+        // Cache chunk loaded status to avoid redundant checks
+        Map<Long, Boolean> chunkLoadedCache = new HashMap<>();
+
         int placed = 0;
-        int skippedNoCollider = 0;
-        int skippedNotAir = 0;
         for (ShipModel.LightSource source : ship.model.lightSources) {
             if (placed >= maxLights) {
                 break;
             }
 
             // Get the collider for this light source's target shulker
-            CollisionBox collider = blockIndexToCollider.get(source.targetShulkerBlockIndex);
+            CollisionBox collider = blockIndexToCollider[source.targetShulkerBlockIndex];
             if (collider == null || collider.entity == null || !collider.entity.isValid()) {
-                skippedNoCollider++;
                 continue;  // No valid shulker for this light
             }
 
             // Get shulker center position (getLocation returns feet, add 0.5 for center)
             Location shulkerLoc = collider.entity.getLocation().add(0, 0.5, 0);
 
-            // Skip if chunk not loaded (avoid forcing chunk loads at boundaries)
-            if (!shulkerLoc.isChunkLoaded()) {
+            // Skip if chunk not loaded (use cache to avoid redundant world queries)
+            int chunkX = shulkerLoc.getBlockX() >> 4;
+            int chunkZ = shulkerLoc.getBlockZ() >> 4;
+            long chunkKey = ((long) chunkX << 32) | (chunkZ & 0xFFFFFFFFL);
+            boolean chunkLoaded = chunkLoadedCache.computeIfAbsent(chunkKey,
+                    k -> world.isChunkLoaded(chunkX, chunkZ));
+            if (!chunkLoaded) {
                 continue;
             }
 
             Block block = shulkerLoc.getBlock();
+            Material blockType = block.getType();
 
-            // Only place if target block is air (don't replace existing blocks)
-            if (block.getType().isAir()) {
+            // Place if target block is air or water (waterlogged light)
+            if (blockType.isAir() || blockType == Material.WATER) {
                 try {
-                    // Create LIGHT block with the appropriate level
                     BlockData lightData = Material.LIGHT.createBlockData();
                     if (lightData instanceof Light light) {
                         light.setLevel(source.lightLevel);
+                        if (blockType == Material.WATER) {
+                            light.setWaterlogged(true);
+                        }
                     }
-                    // Set block without physics update (false) to avoid cascading updates
                     block.setBlockData(lightData, false);
-                    placedLights.add(shulkerLoc.clone());
+                    placedLights.add(new int[]{block.getX(), block.getY(), block.getZ()});
                     placed++;
                 } catch (Exception e) {
-                    // Silently ignore errors (e.g., chunk not loaded)
+                    // Silently ignore errors
                 }
-            } else {
-                skippedNotAir++;
-                ship.plugin.getLogger().info("[ShipLighting] Block at " + block.getX() + "," + block.getY() + "," + block.getZ() + " is " + block.getType());
             }
-        }
-        if (skippedNoCollider > 0 || skippedNotAir > 0) {
-            ship.plugin.getLogger().info("[ShipLighting] Skipped: " + skippedNoCollider + " no collider, " + skippedNotAir + " not air (total sources: " + ship.model.lightSources.size() + ")");
         }
     }
 
@@ -204,20 +214,68 @@ public class ShipLighting {
      * Removes all LIGHT blocks that were placed by this manager.
      */
     public void removePlacedLights() {
-        for (Location loc : placedLights) {
+        World world = ship.vehicle != null && ship.vehicle.isValid() ? ship.vehicle.getWorld() : null;
+        if (world != null) {
+            for (int[] pos : placedLights) {
+                try {
+                    if (world.isChunkLoaded(pos[0] >> 4, pos[2] >> 4)) {
+                        Block block = world.getBlockAt(pos[0], pos[1], pos[2]);
+                        if (block.getType() == Material.LIGHT) {
+                            BlockData data = block.getBlockData();
+                            if (data instanceof Light light && light.isWaterlogged()) {
+                                block.setType(Material.WATER, false);
+                            } else {
+                                block.setType(Material.AIR, false);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    // Silently ignore
+                }
+            }
+        }
+        placedLights.clear();
+    }
+
+    /**
+     * Removes LIGHT blocks at the specified positions.
+     * Skips positions that have new lights placed (to avoid removing lights we just placed).
+     */
+    private void removeOldLights(List<int[]> positions, World world) {
+        for (int[] pos : positions) {
+            // Skip if this position has a new light placed
+            if (hasLightAt(pos[0], pos[1], pos[2])) {
+                continue;
+            }
             try {
-                if (loc.isChunkLoaded()) {
-                    Block block = loc.getBlock();
-                    // Only remove if it's still a LIGHT block (don't remove player-placed blocks)
+                if (world.isChunkLoaded(pos[0] >> 4, pos[2] >> 4)) {
+                    Block block = world.getBlockAt(pos[0], pos[1], pos[2]);
                     if (block.getType() == Material.LIGHT) {
-                        block.setType(Material.AIR, false);
+                        // Restore water if the light was waterlogged
+                        BlockData data = block.getBlockData();
+                        if (data instanceof Light light && light.isWaterlogged()) {
+                            block.setType(Material.WATER, false);
+                        } else {
+                            block.setType(Material.AIR, false);
+                        }
                     }
                 }
             } catch (Exception e) {
                 // Silently ignore errors
             }
         }
-        placedLights.clear();
+    }
+
+    /**
+     * Checks if placedLights contains a light at the same block position.
+     */
+    private boolean hasLightAt(int x, int y, int z) {
+        for (int[] pos : placedLights) {
+            if (pos[0] == x && pos[1] == y && pos[2] == z) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/blockships/src/main/resources/blocks.yml
+++ b/blockships/src/main/resources/blocks.yml
@@ -22,45 +22,54 @@
 
 
 # === FLOATATION BLOCKS (weight: -10, lighter than air) ===
+# These blocks have light_level for fake lighting on ships
 glowstone:
   allowed: true
   weight: -5
   collider: true
+  light_level: 15
 
 sea_lantern:
   allowed: true
   weight: -3
   collider: true
+  light_level: 15
 
 beacon:
   allowed: true
   weight: -15
   collider: true
+  light_level: 15
 
 shroomlight:
   allowed: true
   weight: -5
   collider: true
+  light_level: 15
 
 ochre_froglight:
   allowed: true
   weight: -5
   collider: true
+  light_level: 15
 
 pearlescent_froglight:
   allowed: true
   weight: -5
   collider: true
+  light_level: 15
 
 verdant_froglight:
   allowed: true
   weight: -5
   collider: true
+  light_level: 15
 
 end_rod:
   allowed: true
   weight: -20
   collider: false
+  light_level: 14
 
 
 # === WOOD FAMILY (weight: 2) ===
@@ -329,11 +338,13 @@ redstone_torch:
   allowed: true
   weight: 1
   collider: false
+  light_level: 7
 
 redstone_wall_torch:
   allowed: true
   weight: 1
   collider: false
+  light_level: 7
 
 redstone_block:
   allowed: true
@@ -533,56 +544,67 @@ lectern:
 
 
 # === LIGHTING (weight: 1, except glowstone) ===
+# light_level is used for fake lighting on ships
 torch:
   allowed: true
   weight: 1
   collider: false
+  light_level: 14
 
 wall_torch:
   allowed: true
   weight: 1
   collider: false
+  light_level: 14
 
 soul_torch:
   allowed: true
   weight: 1
   collider: false
+  light_level: 10
 
 soul_wall_torch:
   allowed: true
   weight: 1
   collider: false
+  light_level: 10
 
 lantern:
   allowed: true
   weight: 1
   collider: false
+  light_level: 15
 
 soul_lantern:
   allowed: true
   weight: 1
   collider: false
+  light_level: 10
 
 copper_torch:
   allowed: true
   weight: 1
   collider: false
+  light_level: 14
 
 copper_wall_torch:
   allowed: true
   weight: 1
   collider: false
+  light_level: 14
 
 # Copper lanterns - matches all oxidation variants (copper, exposed, weathered, oxidized, waxed)
 copper_lantern:
   allowed: true
   weight: 1
   collider: false
+  light_level: 15
 
 "*_copper_lantern":
   allowed: true
   weight: 1
   collider: false
+  light_level: 15
 
 # misc
 

--- a/blockships/src/main/resources/config.yml
+++ b/blockships/src/main/resources/config.yml
@@ -33,6 +33,20 @@ custom-ships:
   max-ship-size: 1000  # Maximum number of blocks in a custom ship
   max-scan-size: 5000  # Maximum blocks to scan when ship exceeds limit (for reporting actual size)
 
+  # Fake lighting system for custom ships
+  # Since ship blocks are display entities (not real blocks), light-emitting blocks
+  # don't actually emit light. This system places invisible LIGHT blocks at
+  # corresponding positions to simulate lighting.
+  lighting:
+    # Enable/disable fake lighting (default: true)
+    enabled: true
+    # Maximum number of LIGHT blocks per ship (for performance)
+    max-lights-per-ship: 32
+    # Distance threshold (blocks) - only update lights when ship moves this far
+    update-threshold-blocks: 1.0
+    # Rotation threshold (degrees) - only update lights when ship rotates this much
+    update-threshold-rotation: 10.0
+
   # Buoyancy system - weight-based floating
   # Ships float based on their density (total weight / block count) compared to water density
   # - Density < water: floats higher (surface offset increases)


### PR DESCRIPTION
Ships use display entities rather than real blocks, so light-emitting blocks (torches, glowstone, lanterns, etc.) don't actually emit light. This adds a system that places invisible LIGHT blocks at shulker positions to simulate lighting.

- Detect light sources during ship scanning (excluding interior blocks)
- Place LIGHT blocks at shulker positions for blocks with colliders
- For attachable blocks (torches), use the parent block's shulker
- Threshold-based updates to avoid excessive block manipulation
- Configurable max lights per ship and update thresholds
- Clean up LIGHT blocks on ship destroy/suspend